### PR TITLE
upd(types): fix snowflake db type

### DIFF
--- a/lib/types/resource.d.ts
+++ b/lib/types/resource.d.ts
@@ -1,5 +1,5 @@
 import { EnvironmentIdentifier } from "./environment";
-export declare type ResourceType = "postgres" | "mysql" | "redshift" | "url" | "s3" | "mongodb" | "elasticsearch" | "snowflake" | "bigquey" | "sqlserver" | "cosmosdb";
+export declare type ResourceType = "postgres" | "mysql" | "redshift" | "url" | "s3" | "mongodb" | "elasticsearch" | "snowflakedb" | "bigquey" | "sqlserver" | "cosmosdb";
 export interface ResourceCredentials {
     username: string;
     password: string;

--- a/src/types/resource.ts
+++ b/src/types/resource.ts
@@ -8,7 +8,7 @@ export type ResourceType =
   | "s3"
   | "mongodb"
   | "elasticsearch"
-  | "snowflake"
+  | "snowflakedb"
   | "bigquey"
   | "sqlserver"
   | "cosmosdb";


### PR DESCRIPTION
Part of https://github.com/meroxa/turbine-project/issues/185

Currently, the database will return the value `snowflakedb` (instead of `snowflake`) to signify a Snowflake resource.

This updates the `ResourceType` to reflect this attribute correctly.