### PR TITLE
Add "name" to function create request

### DIFF
--- a/lib/Client.d.ts
+++ b/lib/Client.d.ts
@@ -75,6 +75,7 @@ export default class Client {
         /**
          * Creates a new function.
          * @param {Object} params - The parameters of the function.
+         * @param {string} params.name - The name of the function
          * @param {string} params.input_stream - The name of the input stream.
          * @param {string} params.image - The name of the image.
          * @param {string[]} params.args - The arguments of the function.

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -129,6 +129,7 @@ class Client {
             /**
              * Creates a new function.
              * @param {Object} params - The parameters of the function.
+             * @param {string} params.name - The name of the function
              * @param {string} params.input_stream - The name of the input stream.
              * @param {string} params.image - The name of the image.
              * @param {string[]} params.args - The arguments of the function.

--- a/lib/types/function.d.ts
+++ b/lib/types/function.d.ts
@@ -11,6 +11,7 @@ export interface FunctionStatus {
     details: string;
 }
 export interface CreateFunctionParams {
+    name: string;
     input_stream: string;
     image: string;
     command?: string[];

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -161,6 +161,7 @@ export default class Client {
     /**
      * Creates a new function.
      * @param {Object} params - The parameters of the function.
+     * @param {string} params.name - The name of the function 
      * @param {string} params.input_stream - The name of the input stream.
      * @param {string} params.image - The name of the image.
      * @param {string[]} params.args - The arguments of the function.

--- a/src/types/function.ts
+++ b/src/types/function.ts
@@ -16,6 +16,7 @@ export interface FunctionStatus {
 }
 
 export interface CreateFunctionParams {
+  name: string;
   input_stream: string;
   image: string;
   command?: string[];


### PR DESCRIPTION
In order to populate the function name in notifications in the dashboard we will need to pass the name to platform api. This will allow us to push the name to the `functions/create` endpoint 