### PR TITLE
fix(client): allow configuration of meroxa-account-uuid request header

### DIFF
--- a/.changeset/angry-eels-pull.md
+++ b/.changeset/angry-eels-pull.md
@@ -1,0 +1,5 @@
+---
+"@meroxa/meroxa-js": minor
+---
+
+feat(accounts): allow meroxa-js to make account-specific requests to the platform API

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -31,10 +31,16 @@ export default class Client {
   constructor(options: ClientOptions) {
     const version = options.apiVersion || "v1";
     const apiURL = options.url || "https://api.meroxa.io";
+    const headers = { Authorization: `Bearer ${options.auth}` };
+
+    if (options.accountUUID) {
+      headers['Meroxa-Account-UUID'] = options.accountUUID;
+    }
+
     this.#client = axios.create({
       baseURL: `${apiURL}/${version}`,
       timeout: options?.timeoutMs ?? 10_000,
-      headers: { Authorization: `Bearer ${options.auth}` },
+      headers,
     });
   }
 


### PR DESCRIPTION
Part of https://github.com/meroxa/turbine-project/issues/278

With this change, the meroxa-js `Client` class also accepts an `accountUUID` option which can be passed during client initialization. The `accountUUID` option is then set as the `Meroxa-Account-UUID` request header for outgoing HTTP  requests via `axios`.