### PR TITLE
fix(client): use correct type for account-uuid request header

### DIFF
--- a/.changeset/spotty-nails-tan.md
+++ b/.changeset/spotty-nails-tan.md
@@ -1,0 +1,5 @@
+---
+"@meroxa/meroxa-js": patch
+---
+
+fix(client): use correct type for account-uuid request header

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -23,6 +23,7 @@ export interface ClientOptions {
   timeoutMs?: number;
   url?: string;
   apiVersion?: string;
+  accountUUID?: string;
 }
 
 export default class Client {
@@ -31,11 +32,10 @@ export default class Client {
   constructor(options: ClientOptions) {
     const version = options.apiVersion || "v1";
     const apiURL = options.url || "https://api.meroxa.io";
-    const headers = { Authorization: `Bearer ${options.auth}` };
-
-    if (options.accountUUID) {
-      headers['Meroxa-Account-UUID'] = options.accountUUID;
-    }
+    let headers = {
+      Authorization: `Bearer ${options.auth}`,
+      ...(options?.accountUUID && {'Meroxa-Account-UUID': options.accountUUID})
+    };
 
     this.#client = axios.create({
       baseURL: `${apiURL}/${version}`,


### PR DESCRIPTION
Part of https://github.com/meroxa/turbine-project/issues/278
Follow-up to https://github.com/meroxa/meroxa-js/pull/33

The release Github workflow [failed due to a type error](https://github.com/meroxa/meroxa-js/actions/runs/3252165297/jobs/5338061185) -- this change hopefully resolves the issue, allowing us to release a new version of meroxa-js including the meroxa-account-uuid request header changes.