### PR TITLE
ci(release): ensure package-lock is regenerated

### DIFF
--- a/.changeset/rich-ladybugs-rhyme.md
+++ b/.changeset/rich-ladybugs-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@meroxa/meroxa-js": patch
+---
+
+ci(release): ensure package-lock is regenerated

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Create Release Pull Request or Release to NPM
         uses: changesets/action@v1
         with:
+          version: npm run version
           publish: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.MEROXA_MACHINE }}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build:prod": "npm run clean-build && tsc --sourceMap false",
     "build:watch": "tsc -w",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "release": "npm run build:prod && changeset publish"
+    "release": "npm run build:prod && changeset publish",
+    "version": "changeset version && npm install"
   },
   "author": "Brett Goulder <brett@meroxa.io>",
   "contributors": [


### PR DESCRIPTION
This makes it so that our package-lock is regenerated with the new version during a release